### PR TITLE
docs: fix dead link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ $ forge script script/Deploy.s.sol --broadcast --fork-url http://localhost:8545
 ```
 
 For instructions on how to deploy to a testnet or mainnet, check out the
-[Solidity Scripting](https://book.getfoundry.sh/tutorials/solidity-scripting.html) tutorial.
+[Solidity Scripting](https://book.getfoundry.sh/guides/scripting-with-solidity) tutorial.
 
 
 ## Verify Contracts


### PR DESCRIPTION
Hi! I fixes a dead link in the README.md file. The outdated link pointing to the old Foundry Solidity scripting tutorial (https://book.getfoundry.sh/tutorials/solidity-scripting.html) has been replaced with the correct and updated link (https://book.getfoundry.sh/guides/scripting-with-solidity).