### PR TITLE
fix: fix incorrect mapping type for allowed tokens

### DIFF
--- a/contracts/L2/RsETHTokenWrapper.sol
+++ b/contracts/L2/RsETHTokenWrapper.sol
@@ -21,7 +21,7 @@ contract RsETHTokenWrapper is Initializable, AccessControlUpgradeable, ERC20Upgr
     bytes32 public constant MANAGER_ROLE = keccak256("MANAGER_ROLE");
 
     /// @dev The address of the alternative RsETH token
-    mapping(address allowedToken => bool isAllowed) public allowedTokens;
+    mapping(address => bool) public allowedTokens;
 
     bytes32 public constant MINTER_ROLE = keccak256("MINTER_ROLE");
     bytes32 public constant BRIDGER_ROLE = keccak256("BRIDGER_ROLE");


### PR DESCRIPTION
I’ve corrected the issue with the `allowedToken => bool isAllowed` mapping.

The proper structure should be `address => bool`, ensuring that the mapping holds a boolean value for each address, as intended. This change aligns the code with the expected behavior.